### PR TITLE
nc-sa-2020-015.json: update 16.x comparison

### DIFF
--- a/server/nc-sa-2020-015.json
+++ b/server/nc-sa-2020-015.json
@@ -23,7 +23,7 @@
          "Operator":"<"
       },
       {
-         "Version":"16.0.10",
+         "Version":"16.0.9",
          "CVE":"CVE assignment pending",
          "Operator":"<"
       }


### PR DESCRIPTION
Turns out, this was a typo, and this is already fixed in 16.0.9 by
https://github.com/nextcloud/server/pull/19362.

See https://github.com/nextcloud/server/issues/19976 for context.

Closes: https://github.com/nextcloud/server/issues/19976